### PR TITLE
Avoid attempting to authenticate on internal requests

### DIFF
--- a/lib/class-wp-json-authentication-oauth1.php
+++ b/lib/class-wp-json-authentication-oauth1.php
@@ -28,6 +28,14 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 	protected $auth_status = null;
 
 	/**
+	 * Should we attempt to run?
+	 *
+	 * Stops infinite recursion in certain circumstances.
+	 * @var boolean
+	 */
+	protected $should_attempt = true;
+
+	/**
 	 * Parse the Authorization header into parameters
 	 *
 	 * @param string $header Authorization header value (not including "Authorization: " prefix)
@@ -129,7 +137,7 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 	 * @return WP_User|null|WP_Error Authenticated user on success, null if no OAuth data supplied, error otherwise
 	 */
 	public function authenticate( $user ) {
-		if ( ! empty( $user ) ) {
+		if ( ! empty( $user ) || ! $this->should_attempt ) {
 			return $user;
 		}
 

--- a/lib/class-wp-json-authentication.php
+++ b/lib/class-wp-json-authentication.php
@@ -31,6 +31,8 @@ abstract class WP_JSON_Authentication {
 	abstract public function authenticate( $user );
 
 	public function get_consumer( $key ) {
+		$this->should_attempt = false;
+
 		$query = new WP_Query();
 		$consumers = $query->query( array(
 			'post_type' => 'json_consumer',
@@ -46,6 +48,8 @@ abstract class WP_JSON_Authentication {
 				),
 			),
 		) );
+
+		$this->should_attempt = true;
 
 		if ( empty( $consumers ) || empty( $consumers[0] ) )
 			return new WP_Error( 'json_consumer_notfound', __( 'Consumer Key is invalid' ), array( 'status' => 401 ) );


### PR DESCRIPTION
Internal WP_Query calls can cause infinite recursion in certain circumstances. We need to mitigate this.
