### PR TITLE
Don't override error responses from other handlers

### DIFF
--- a/lib/class-wp-json-authentication-oauth1.php
+++ b/lib/class-wp-json-authentication-oauth1.php
@@ -186,9 +186,14 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 	/**
 	 * Report authentication errors to the JSON API
 	 *
+	 * @param WP_Error|mixed $result Error from another authentication handler, null if we should handle it, or another value if not
 	 * @return WP_Error|boolean|null {@see WP_JSON_Server::check_authentication}
 	 */
-	public function get_authentication_errors() {
+	public function get_authentication_errors( $value ) {
+		if ( $value !== null ) {
+			return $value;
+		}
+
 		return $this->auth_status;
 	}
 


### PR DESCRIPTION
We should never touch responses that other handlers have already set.

See WP-API/Basic-Auth#5, WP-API/Basic-Auth#8, WP-API/WP-API#340
