### PR TITLE
Remove vagrant-hostsupdater from Chassis instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ testing environment in a few easy steps:
 
    ```bash
    git clone --recursive git@github.com:Chassis/Chassis.git api-tester
-   vagrant plugin install vagrant-hostsupdater
    ```
 
 3. Grab a copy of WP API and OAuth API:


### PR DESCRIPTION
I just noticed in the readme that there was still instructions for installing vagrant-hostsupdater. Chassis doesn't require [vagrant-hostsupdater](https://github.com/Chassis/Chassis/commit/134c00d6d1513c2ed5a229866cb8635bff5cf404) any more thankfully so we can remove that now :sparkles: 
