### PR TITLE
check_oauth_signature now filters out any non-oauth parameters before no...

### DIFF
--- a/lib/class-wp-json-authentication-oauth1.php
+++ b/lib/class-wp-json-authentication-oauth1.php
@@ -519,7 +519,16 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 				break;
 		}
 
-		$params = array_merge( $params, $oauth_params );
+		// Filter out any non-oauth keys so they don't interfere with normalization and signature generation.
+		$oauth_params = array_merge( $params, $oauth_params );
+		unset ($params);
+		$params = array();
+		
+		foreach ( $oauth_params as $param_key => $param_value ) {
+			if (substr($param_key, 0, 6) === 'oauth_') {
+				$params[$param_key] = $param_value;
+			}
+		}
 
 		$base_request_uri = rawurlencode( get_home_url( null, parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ), 'http' ) );
 


### PR DESCRIPTION
When posting data to the API, API and OAuth $_POST parameters may be passed up. This code filters non-oauth parameters out so that no errors occur when normalizing and then generating the OAuth signature for comparison.
