### PR TITLE
Added support for WP blogs that reside in the folder of a domain.

### DIFF
--- a/lib/class-wp-json-authentication-oauth1.php
+++ b/lib/class-wp-json-authentication-oauth1.php
@@ -521,7 +521,13 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 
 		$params = array_merge( $params, $oauth_params );
 
-		$base_request_uri = rawurlencode( get_home_url( null, parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ), 'http' ) );
+		// Support WP blog roots that point to a folder and not just a domain
+		$home_url_path = parse_url(get_home_url (null,'','http'), PHP_URL_PATH );
+		$request_uri_path = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+		if (substr($request_uri_path, 0, strlen($home_url_path)) == $home_url_path) {
+			$request_uri_path = substr($request_uri_path, strlen($home_url_path));
+		}
+		$base_request_uri = rawurlencode( get_home_url( null, $request_uri_path, 'http' ) );
 
 		// get the signature provided by the consumer and remove it from the parameters prior to checking the signature
 		$consumer_signature = rawurldecode( $params['oauth_signature'] );

--- a/lib/class-wp-json-authentication-oauth1.php
+++ b/lib/class-wp-json-authentication-oauth1.php
@@ -522,12 +522,12 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 		$params = array_merge( $params, $oauth_params );
 
 		// Support WP blog roots that point to a folder and not just a domain
-		$home_url_path = parse_url(get_home_url (null,'','http'), PHP_URL_PATH );
+		$home_url_path = parse_url(get_home_url (null,''), PHP_URL_PATH );
 		$request_uri_path = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
 		if (substr($request_uri_path, 0, strlen($home_url_path)) == $home_url_path) {
 			$request_uri_path = substr($request_uri_path, strlen($home_url_path));
 		}
-		$base_request_uri = rawurlencode( get_home_url( null, $request_uri_path, 'http' ) );
+		$base_request_uri = rawurlencode( get_home_url( null, $request_uri_path ) );
 
 		// get the signature provided by the consumer and remove it from the parameters prior to checking the signature
 		$consumer_signature = rawurldecode( $params['oauth_signature'] );


### PR DESCRIPTION
When checking the OAuth signature, the comparison would fail if the WP blog was in a folder under the host. This code fixes the issue. It could probably be condensed but it gets the job done.