### PR TITLE
Update Oauth authorization view - nicer styles

### DIFF
--- a/theme/oauth1-authorize.php
+++ b/theme/oauth1-authorize.php
@@ -8,19 +8,69 @@ login_header(
 $current_user = wp_get_current_user();
 
 $url = site_url( 'wp-login.php?action=oauth1_authorize', 'login_post' );
+
 ?>
+
+<style>
+
+	.login-title {
+		margin-bottom: 15px;
+	}
+
+	.login-info .avatar {
+		margin-right: 15px;
+		margin-bottom: 15px;
+		float: left;
+	}
+
+	#login form .login-info p {
+		margin-bottom: 15px;
+	}
+
+	/** Note - login scope has not yet been implemented. **/
+	.login-scope {
+		clear: both;
+		margin-bottom: 15px;
+	}
+
+	.login-scope h4 {
+		margin-bottom: 10px;
+	}
+
+	.login-scope ul {
+		margin-left: 1.5em;
+	}
+
+	.submit {
+		clear: both;
+	}
+
+	.submit .button {
+		margin-right: 10px;
+		float: left;
+	}
+
+</style>
 
 <form name="oauth1_authorize_form" id="oauth1_authorize_form" action="<?php echo esc_url( $url ); ?>" method="post">
 
-	<h2><?php echo esc_html( sprintf( __('Connect %1$s'), $consumer->post_title ) ) ?></h2>
-	<p><?php
-		printf(
-			__( 'Howdy <strong>%1$s</strong>, "%2$s" would like to connect to %3$s.' ),
-			$current_user->user_login,
-			$consumer->post_title,
-			get_bloginfo( 'name' )
-		)
-	?></p>
+	<h2 class="login-title"><?php echo esc_html( sprintf( __('Connect %1$s'), $consumer->post_title ) ) ?></h2>
+
+	<div class="login-info">
+
+		<?php echo get_avatar( $current_user->ID, '78' ); ?>
+
+		<p><?php
+			printf(
+				__( 'Howdy <strong>%1$s</strong>,<br/> "%2$s" would like to connect to %3$s.' ),
+				$current_user->user_login,
+				$consumer->post_title,
+				get_bloginfo( 'name' )
+			)
+		?></p>
+
+	</div>
+
 	<?php
 	/**
 	 * Fires inside the lostpassword <form> tags, before the hidden fields.
@@ -29,9 +79,10 @@ $url = site_url( 'wp-login.php?action=oauth1_authorize', 'login_post' );
 	 */
 	do_action( 'oauth1_authorize_form', $consumer ); ?>
 	<p class="submit">
-		<button type="submit" name="wp-submit" value="cancel" class="button button-primary button-large"><?php _e('Cancel'); ?></button>
 		<button type="submit" name="wp-submit" value="authorize" class="button button-primary button-large"><?php _e('Authorize'); ?></button>
+		<button type="submit" name="wp-submit" value="cancel" class="button button-large"><?php _e('Cancel'); ?></button>
 	</p>
+
 </form>
 
 <p id="nav">


### PR DESCRIPTION
Make the oauth authorization view look a bit nicer.

Add user avatar and added a few styles. 

![image](https://cloud.githubusercontent.com/assets/494927/4442323/1ce5ddbe-47de-11e4-8ecb-765e17091845.png)

TODO - add info on 'scopes' - I added some styles for this but as its not implemented yet I have removed any HTML.

Taken some inspiration from the 'connect with Jetpack' auth screen - see example here: https://wp-stream.com/
