### PR TITLE
wrong hash_hmac key generating

### DIFF
--- a/lib/class-wp-json-authentication-oauth1.php
+++ b/lib/class-wp-json-authentication-oauth1.php
@@ -568,11 +568,10 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 
 		$token = (array) $token;
 		$string_to_sign = $http_method . '&' . $base_request_uri . '&' . $query_string;
-		$key_parts = array(
-			$consumer->secret,
-			( $token ? $token['secret'] : '' )
-		);
-		$key = implode( '&', $key_parts );
+		$key = $consumer->secret;
+		if (!empty($token) && isset($token['secret'])) {
+			$key .= '&'.$token['secret'];
+		}
 
 		switch ($params['oauth_signature_method']) {
 			case 'HMAC-SHA1':


### PR DESCRIPTION
When the $token is empty the $key_parts array contain second value empty, so "implode" will generate key with unwanted ampersand at the end.