### PR TITLE
wrong $base_request_uri when blog is in subdir

### DIFF
--- a/lib/class-wp-json-authentication-oauth1.php
+++ b/lib/class-wp-json-authentication-oauth1.php
@@ -551,8 +551,6 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 
 		$params = array_merge( $params, $oauth_params );
 
-		$base_request_uri = rawurlencode( get_home_url( null, parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) ) );
-		
 		$url_path = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH);
 		$home_url_parts = parse_url(get_home_url( null, '' ));
 		$home_url = $home_url_parts['scheme'].'://'.$home_url_parts['host'].$url_path;

--- a/lib/class-wp-json-authentication-oauth1.php
+++ b/lib/class-wp-json-authentication-oauth1.php
@@ -552,7 +552,12 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 		$params = array_merge( $params, $oauth_params );
 
 		$base_request_uri = rawurlencode( get_home_url( null, parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) ) );
-
+		
+		$url_path = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH);
+		$home_url_parts = parse_url(get_home_url( null, '' ));
+		$home_url = $home_url_parts['scheme'].'://'.$home_url_parts['host'].$url_path;
+		$base_request_uri = rawurlencode( $home_url );
+		
 		// get the signature provided by the consumer and remove it from the parameters prior to checking the signature
 		$consumer_signature = rawurldecode( $params['oauth_signature'] );
 		unset( $params['oauth_signature'] );


### PR DESCRIPTION
Case:
  wordpress home url: http://domain.wrdp/blog/
  $_SERVER['REQUEST_URI'] = http://domain.wrdp/blog/ouath1/request
In this case:
  parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH) = 'blog/ouath1/request';
  get_home_url( null, '') = 'http://domain.wrdp/blog/';

base_request_uri = parse_url + get_home_url = 'http://domain.wrdp/blog/blog/ouath1/request';