### PR TITLE
Fix signature for params with special chars

### DIFF
--- a/lib/class-wp-json-authentication-oauth1.php
+++ b/lib/class-wp-json-authentication-oauth1.php
@@ -624,7 +624,7 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 				if ( $key ) {
 					$param_key = $key . '[' . $param_key . ']'; // Handle multi-dimensional array
 				}
-				$string = $param_key . '=' . $param_value; // join with equals sign
+				$string = urlencode( $param_key ) . '=' . urlencode( $param_value ); // join with equals sign
 				$query_params[] = urlencode( $string );
 			}
 		}


### PR DESCRIPTION
Parameters with special characters that needs encoding should be encoded twice:

1. Encode as they are part of a URL, so they must be encoded;
2. Encode to join as the base string for signature.

See #34
