### PR TITLE
Add filter to signal error for WP-API v2

### DIFF
--- a/lib/class-wp-json-authentication.php
+++ b/lib/class-wp-json-authentication.php
@@ -26,9 +26,12 @@ abstract class WP_JSON_Authentication {
 		}
 
 		add_filter( 'json_check_authentication', array( $this, 'authenticate' ), 0 );
+		add_filter( 'rest_authentication_errors', array( $this, 'get_authentication_errors' ), 0 );
 	}
 
 	abstract public function authenticate( $user );
+
+	abstract public function get_authentication_errors( $value );
 
 	public function get_consumer( $key ) {
 		$this->should_attempt = false;


### PR DESCRIPTION
WP-API v2 uses filter 'rest_authentication_errors' to check for authentication errors.

Add filter to return a proper error to WP-API v2 when something went wrong with OAuth authentication.