### PR TITLE
Remove unset of post_title and post_content before inserting consumer object

### DIFF
--- a/lib/class-wp-json-authentication.php
+++ b/lib/class-wp-json-authentication.php
@@ -68,12 +68,11 @@ abstract class WP_JSON_Authentication {
 		);
 		$params = wp_parse_args( $params, $default );
 
-		$data = array();
-		$data['post_title'] = $params['name'];
-		$data['post_content'] = $params['description'];
-		unset( $data['post_title'], $data['post_content'] );
-
-		$data['post_type'] = 'json_consumer';
+		$data = array(
+			'post_type' => 'json_consumer',
+			'post_title' => $params['name'],
+			'post_content' => $params['description'],
+		);
 
 		$ID = wp_insert_post( $data );
 		if ( is_wp_error( $ID ) ) {


### PR DESCRIPTION
Fixes #87 – And allows consumers to have actual names.