### PR TITLE
Fix Signature and Callback (Issues WP-API/OAuth1#59, WP-API/OAuth1#64, WP-API/OAuth1#91)

### DIFF
--- a/lib/class-wp-json-authentication-oauth1.php
+++ b/lib/class-wp-json-authentication-oauth1.php
@@ -50,7 +50,7 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 		$params = array();
 		if ( preg_match_all( '/(oauth_[a-z_-]*)=(:?"([^"]*)"|([^,]*))/', $header, $matches ) ) {
 			foreach ($matches[1] as $i => $h) {
-				$params[$h] = urldecode( empty($matches[3][$i]) ? $matches[4][$i] : $matches[3][$i] );
+				$params[$h] = rawurldecode( empty($matches[3][$i]) ? $matches[4][$i] : $matches[3][$i] );
 			}
 			if (isset($params['realm'])) {
 				unset($params['realm']);
@@ -551,7 +551,7 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 
 		$params = array_merge( $params, $oauth_params );
 
-		$base_request_uri = rawurlencode( get_home_url( null, parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) ) );
+		$base_request_uri = get_home_url( null, parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) );
 
 		// get the signature provided by the consumer and remove it from the parameters prior to checking the signature
 		$consumer_signature = rawurldecode( $params['oauth_signature'] );
@@ -567,7 +567,7 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 		$query_string = $this->create_signature_string( $params );
 
 		$token = (array) $token;
-		$string_to_sign = $http_method . '&' . $base_request_uri . '&' . $query_string;
+		$string_to_sign = $http_method . '&' . rawurlencode( $base_request_uri ) . '&' . rawurlencode( $query_string );
 		$key_parts = array(
 			$consumer->secret,
 			( $token ? $token['secret'] : '' )
@@ -604,7 +604,7 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 	 * @return string         Signature string
 	 */
 	public function create_signature_string( $params ) {
-		return implode( '%26', $this->join_with_equals_sign( $params ) ); // join with ampersand
+		return implode( '&', $this->join_with_equals_sign( $params ) ); // join with ampersand
 	}
 
 	/**
@@ -624,8 +624,8 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 				if ( $key ) {
 					$param_key = $key . '[' . $param_key . ']'; // Handle multi-dimensional array
 				}
-				$string = $param_key . '=' . $param_value; // join with equals sign
-				$query_params[] = urlencode( $string );
+				$string = rawurlencode( $param_key ) . '=' . rawurlencode( $param_value ); // join with equals sign
+				$query_params[] = $string;
 			}
 		}
 		return $query_params;

--- a/lib/class-wp-json-authentication-oauth1.php
+++ b/lib/class-wp-json-authentication-oauth1.php
@@ -365,13 +365,14 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 
 		// Generate token
 		$key = apply_filters( 'json_oauth1_request_token_key', wp_generate_password( self::TOKEN_KEY_LENGTH, false ) );
+		$callback = $params['oauth_callback'];
 		$data = array(
 			'key'        => $key,
 			'secret'     => wp_generate_password( self::TOKEN_SECRET_LENGTH, false ),
 			'consumer'   => $consumer->ID,
 			'authorized' => false,
 			'expiration' => time() + 24 * HOUR_IN_SECONDS,
-			'callback'   => null,
+			'callback'   => $callback,
 			'verifier'   => null,
 			'user'       => null,
 		);

--- a/lib/class-wp-json-authentication-oauth1.php
+++ b/lib/class-wp-json-authentication-oauth1.php
@@ -557,9 +557,6 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 		$consumer_signature = rawurldecode( $params['oauth_signature'] );
 		unset( $params['oauth_signature'] );
 
-		// normalize parameter key/values
-		array_walk_recursive( $params, array( $this, 'normalize_parameters' ) );
-
 		// sort parameters
 		if ( ! uksort( $params, 'strcmp' ) )
 			return new WP_Error( 'json_oauth1_failed_parameter_sort', __( 'Invalid Signature - failed to sort parameters' ), array( 'status' => 401 ) );
@@ -629,20 +626,6 @@ class WP_JSON_Authentication_OAuth1 extends WP_JSON_Authentication {
 			}
 		}
 		return $query_params;
-	}
-
-	/**
-	 * Normalize each parameter by assuming each parameter may have already been encoded, so attempt to decode, and then
-	 * re-encode according to RFC 3986
-	 *
-	 * @since 2.1
-	 * @see rawurlencode()
-	 * @param string $key
-	 * @param string $value
-	 */
-	protected function normalize_parameters( &$key, &$value ) {
-		$key = rawurlencode( rawurldecode( $key ) );
-		$value = rawurlencode( rawurldecode( $value ) );
 	}
 
 	/**


### PR DESCRIPTION
This Pull Request integrates commits from 2 other Pull Requests.
All together, it accomplishes:
1. Replaces urlencode/urldecode with rawurlencode/rawurldecode calls for more URI correctness.
2. Stops the decode/re-encode of parameters which may already have portions of them encoded.
3. Correctly generates an oauth_signature regardless of '+' or encoded parameters contained within the signature string.
4. Stores the oauth_callback parameter for use with oauth_callback_confirmed in the 1.0a spec.

### AlexC's commit: Ensure OAuth1 signature is created as per the spec
This commit fixes signature generation for certain cases, however it adds an extra encoding in addition to normalize_parameters which can cause an issue (addressed below.)

### coderkevin's commit: Remove normalize_parameters function
This commit fixes WP-API/OAuth1#91 and relies on AlexC's commit above to encode inside of join_with_equals_sign() to encode parameters as the param string is generated.

### sblaz's commit: Fix issue WP-API/OAuth#59, OAuth callback isn't called
This commit stores and carries over the oauth_callback parameter for post-authentication. It relies on the above two commits to ensure the callback parameter remains correctly encoded.
