### PR TITLE
Fixed bug in Profile > Authorized Applications

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -343,7 +343,7 @@ function json_oauth_profile_section( $user ) {
 							<tbody>
 							<?php foreach ( $approved as $row ): ?>
 								<?php
-								$application = rest_get_client( 'oauth1', $row['consumer'] );
+								$application = get_post($row['consumer']);
 								?>
 								<tr>
 									<td><?php echo esc_html( $application->post_title ) ?></td>

--- a/admin.php
+++ b/admin.php
@@ -331,6 +331,7 @@ function json_oauth_profile_section( $user ) {
 		<table class="form-table">
 			<tbody>
 			<tr>
+				<th></th>
 				<th scope="row"><?php _e( 'Authorized Applications', 'json_oauth' ) ?></th>
 				<td>
 					<?php if ( ! empty( $approved ) ): ?>

--- a/admin.php
+++ b/admin.php
@@ -331,14 +331,14 @@ function json_oauth_profile_section( $user ) {
 		<table class="form-table">
 			<tbody>
 			<tr>
-				<th></th>
 				<th scope="row"><?php _e( 'Authorized Applications', 'json_oauth' ) ?></th>
 				<td>
 					<?php if ( ! empty( $approved ) ): ?>
-						<table class="widefat sessions-table">
+						<table class="widefat">
 							<thead>
 							<tr>
-								<th scope="col"><?php _e( 'Application Name', 'wpsm' ); ?></th>
+								<th style="padding-left:10px;"><?php _e( 'Application Name', 'wpsm' ); ?></th>
+								<th></th>
 							</tr>
 							</thead>
 							<tbody>


### PR DESCRIPTION
Currently there is a bug in the WP-Admin > Users > Your Profile in the list of Authorized Applications. The name of the consumer application is not being displayed. 

The current code has the consumer being looked up using `rest_get_client()`. 

The array of `$approved` applications contains the consumer ID in the `$row`. This is simply the `json_consumer` type post in wp_posts, so modified to simply use `get_post()`. 

[ Alternatively, I suppose we could use a `$wpdb` SELECT post_title .. query, since we've already pulled that into global. More efficient? ] 

