### PR TITLE
Run `authenticate` in `get_authentication_errors`

### DIFF
--- a/lib/class-wp-rest-oauth1.php
+++ b/lib/class-wp-rest-oauth1.php
@@ -221,6 +221,8 @@ class WP_REST_OAuth1 {
 			return $value;
 		}
 
+		$this->authenticate( null );
+
 		return $this->auth_status;
 	}
 

--- a/oauth-server.php
+++ b/oauth-server.php
@@ -74,7 +74,6 @@ function rest_oauth1_load() {
 	global $wp_json_authentication_oauth1;
 
 	$wp_json_authentication_oauth1 = new WP_REST_OAuth1();
-	add_filter( 'determine_current_user', array( $wp_json_authentication_oauth1, 'authenticate' ) );
 	add_filter( 'rest_authentication_errors', array( $wp_json_authentication_oauth1, 'get_authentication_errors' ) );
 }
 add_action( 'init', 'rest_oauth1_load' );


### PR DESCRIPTION
Fixes an issue where logged in users could not authenticate requests with their OAuth credentials.
- Removes hooking of `authenticate` on `determin_current_user` (which doesn't run or runst too late when the user presents login cookies)
- Instead, authenticate directly in `rest_authentication_errors` callback
