### PR TITLE
Fix signature for params with special chars

### DIFF
--- a/lib/class-wp-rest-oauth1.php
+++ b/lib/class-wp-rest-oauth1.php
@@ -731,7 +731,7 @@ class WP_REST_OAuth1 {
 				if ( $key ) {
 					$param_key = $key . '[' . $param_key . ']'; // Handle multi-dimensional array
 				}
-				$string = $param_key . '=' . $param_value; // join with equals sign
+				$string = urlencode( $param_key ) . '=' . urlencode( $param_value ); // join with equals sign
 				$query_params[] = urlencode( $string );
 			}
 		}


### PR DESCRIPTION
(This change was originally proposed by @thiago-negri in PR #79. More details there.)

Without this patch, requests for URLs containing special characters like `[]` break OAuth authentication.