### PR TITLE
Clear usermeta nonces (Issue #67)

### DIFF
--- a/lib/class-wp-rest-oauth1.php
+++ b/lib/class-wp-rest-oauth1.php
@@ -786,7 +786,7 @@ class WP_REST_OAuth1 {
 
 		// Remove expired nonces
 		foreach ( $used_nonces as $nonce_timestamp => $nonce ) {
-			if ( $nonce_timestamp < $valid_window )
+			if ( $nonce_timestamp < time() - $valid_window )
 				unset( $used_nonces[ $nonce_timestamp ] );
 		}
 

--- a/lib/class-wp-rest-oauth1.php
+++ b/lib/class-wp-rest-oauth1.php
@@ -783,10 +783,15 @@ class WP_REST_OAuth1 {
 			return new WP_Error( 'json_oauth1_nonce_already_used', __( 'Invalid nonce - nonce has already been used', 'rest_oauth1' ), array( 'status' => 401 ) );
 
 		$used_nonces[ $timestamp ] = $nonce;
-
+		
+		// Get the current time
+		$current_time = time();
+		
 		// Remove expired nonces
 		foreach ( $used_nonces as $nonce_timestamp => $nonce ) {
-			if ( $nonce_timestamp < time() - $valid_window )
+			
+			// If the nonce timestamp is expired
+			if ( $nonce_timestamp < $current_time - $valid_window )
 				unset( $used_nonces[ $nonce_timestamp ] );
 		}
 


### PR DESCRIPTION
Address nonces not being cleared from usermeta: https://github.com/WP-API/OAuth1/issues/67

Some context on why this needs to be fixed asap: 
We're using the REST API to migrate a site, and we were realizing that after each post we created, the requests were getting incrementally slower, until we were at the point where our database was basically non-responsive. . .we discovered that our "migration" user had 588,000 timestamp/nonce key/value pairs stored in the usermeta under "nonces". . .so anyone doing multiple API requests will get slower by the request, and after enough requests will really have issues. Not sure how we let it get to 588,000 nonces before realizing what the issue was. lol.