### PR TITLE
Consistently use rawurldecode

### DIFF
--- a/lib/class-wp-rest-oauth1.php
+++ b/lib/class-wp-rest-oauth1.php
@@ -48,7 +48,7 @@ class WP_REST_OAuth1 {
 		$params = array();
 		if ( preg_match_all( '/(oauth_[a-z_-]*)=(:?"([^"]*)"|([^,]*))/', $header, $matches ) ) {
 			foreach ($matches[1] as $i => $h) {
-				$params[$h] = urldecode( empty($matches[3][$i]) ? $matches[4][$i] : $matches[3][$i] );
+				$params[$h] = rawurldecode( empty($matches[3][$i]) ? $matches[4][$i] : $matches[3][$i] );
 			}
 			if (isset($params['realm'])) {
 				unset($params['realm']);


### PR DESCRIPTION
The `urldecode` function converts '+' to ' '. Because '+' is a valid Base64 character, it needs to be preserved in OAuth signatures. Using `rawurldecode` preserves '+' but behaves the same as `urldecode` in every other respect.