### PR TITLE
fixed compatibility with "ddo/oauth-1.0a"

### DIFF
--- a/lib/class-wp-rest-oauth1.php
+++ b/lib/class-wp-rest-oauth1.php
@@ -684,6 +684,10 @@ class WP_REST_OAuth1 {
 			( $token ? $token['secret'] : '' )
 		);
 		$key = implode( '&', $key_parts );
+		
+		// only use the secret without the token as the hash key
+		$cut_pos = strpos($key, '&');
+		$key = substr($key, 0, $cut_pos + 1);
 
 		switch ($params['oauth_signature_method']) {
 			case 'HMAC-SHA1':


### PR DESCRIPTION
only use the secret without the token as the hash key
fix for issue #146 

please be careful as this might break compatibilities with other libraries..