### PR TITLE
Properly show verification UI during out-of-band flow

### DIFF
--- a/lib/class-wp-rest-oauth1-ui.php
+++ b/lib/class-wp-rest-oauth1-ui.php
@@ -136,11 +136,7 @@ class WP_REST_OAuth1_UI {
 	 * @return null|WP_Error Null on success, error otherwise
 	 */
 	public function handle_callback_redirect( $verifier ) {
-		if ( ! empty( $this->token['callback'] ) && $this->token['callback'] === 'oob' ) {
-			return apply_filters( 'json_oauth1_handle_callback', null, $this->token );
-		}
-
-		if ( empty( $this->token['callback'] ) ) {
+		if ( empty( $this->token['callback'] ) || $this->token['callback'] === 'oob' ) {
 			// No callback registered, display verification code to the user
 			login_header( __( 'Access Token', 'rest_oauth1' ) );
 			echo '<p>' . sprintf( __( 'Your verification token is <code>%s</code>', 'rest_oauth1' ), $verifier ) . '</p>';


### PR DESCRIPTION
The conditional in this function makes it so that a callback of "oob" will never trigger the UI view that allows a user to manually copy their verification code for out-of-band OAuth flow.

This commit does not necessarily resolve #149, which is about the OOB UI showing up when it's _not_ supposed to; but at least this does make OOB verification work in my test environment.