### PR TITLE
Add missing 'patch' http method

### DIFF
--- a/lib/class-wp-rest-oauth1.php
+++ b/lib/class-wp-rest-oauth1.php
@@ -647,6 +647,7 @@ class WP_REST_OAuth1 {
 
 			case 'POST':
 			case 'PUT':
+			case 'PATCH':
 				$params = wp_unslash( $_POST );
 				break;
 			default:


### PR DESCRIPTION
Http method 'patch' needs to be supported to be fully compatible with WP Rest API v2.