### PR TITLE
Change access tokens into a post type.

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -17,19 +17,20 @@ add_action( 'edit_user_profile_update', 'rest_oauth1_profile_save', 10, 1 );
 function rest_oauth1_profile_section( $user ) {
 	global $wpdb;
 
-	$results = $wpdb->get_col( "SELECT option_value FROM {$wpdb->options} WHERE option_name LIKE 'oauth1_access_%'", 0 );
-	$approved = array();
-	foreach ( $results as $result ) {
-		$row = unserialize( $result );
-		if ( $row['user'] === $user->ID ) {
-			$approved[] = $row;
-		}
-	}
+	$post_list     = get_posts( array(
+		'author'           => $user->ID,
+		'post_type'        => 'oauth1_access_token',
+		'posts_per_page'   => 100,
+		'suppress_filters' => false,
 
+    ) );
+	$approved      = array();
 	$authenticator = new WP_REST_OAuth1();
-
+	foreach ( $post_list as $result ) {
+		$approved[] = $authenticator->get_access_token( $result->post_name );
+	}
 	?>
-		<table class="form-table">
+    <table class="form-table">
 			<tbody>
 			<tr>
 				<th scope="row"><?php _e( 'Authorized Applications', 'rest_oauth1' ) ?></th>

--- a/oauth-server.php
+++ b/oauth-server.php
@@ -61,6 +61,18 @@ function rest_oauth1_setup_authentication() {
 		'delete_with_user' => true,
 		'query_var' => false,
 	) );
+
+	register_post_type( 'oauth1_access_token', array(
+		'labels' => array(
+			'name' => __( 'Access Token', 'rest_oauth1' ),
+			'singular_name' => __( 'Access Tokens', 'rest_oauth1' ),
+		),
+		'public' => false,
+		'hierarchical' => false,
+		'rewrite' => false,
+		'delete_with_user' => true,
+		'query_var' => false,
+	) );
 }
 add_action( 'init', 'rest_oauth1_setup_authentication' );
 


### PR DESCRIPTION
Moving access tokens to a post type makes a lot of sense. It means they are deleted when the user is deleted. 

There are some backwards compatablity issues, but I believe I have done a good job in fixing these, by support the old options and copying them over to post type. 

Fixes #215