### PR TITLE
Replace get_class with __CLASS__

### DIFF
--- a/lib/class-wp-rest-oauth1-admin.php
+++ b/lib/class-wp-rest-oauth1-admin.php
@@ -24,7 +24,7 @@ class WP_REST_OAuth1_Admin {
 		 */
 		include_once __DIR__ . '/class-wp-rest-oauth1-listtable.php';
 
-		$class = get_class();
+		$class = __CLASS__;
 
 		$hook = add_users_page(
 			// Page title.


### PR DESCRIPTION
Fixes #233

Avoiding to this article, we can use `__CLASS__` magic constant and it should work with PHP 5.4. 
 
https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated