### PR TITLE
Added an hook for base_request_uri

### DIFF
--- a/lib/class-wp-rest-oauth1.php
+++ b/lib/class-wp-rest-oauth1.php
@@ -700,7 +700,7 @@ class WP_REST_OAuth1 {
 		if ( substr( $request_path, 0, strlen( $wp_base ) ) === $wp_base ) {
 			$request_path = substr( $request_path, strlen( $wp_base ) );
 		}
-		$base_request_uri = self::urlencode_rfc3986( get_home_url( null, $request_path ) );
+        $base_request_uri = self::urlencode_rfc3986( apply_filters( 'oauth1_base_request_uri', get_home_url( null, $request_path ) ));
 
 		// get the signature provided by the consumer and remove it from the parameters prior to checking the signature.
 		$consumer_signature = rawurldecode( $params['oauth_signature'] );


### PR DESCRIPTION
This change was necessary because, in our case, we have a website that needs to respond to different urls, and currently, the plugin breaks because it assumes a fixed base url.
This causes issues during the OAuth signature verification, where the generated signature doesn't match, resulting in the "OAuth signature does not match" error.

To address this, we've introduced a new hook that allows us to intercept and modify the base url before the signature is generated. This change provides flexibility for anyone facing similar issues, giving them the opportunity to adjust the base url dynamically to match their specific setup.


For example, with this hook, one could implement the following function:

> function customized_oauth1_base_request_uri($url)
> {
>     return str_replace(<fixed_base_url>, <new_base_url>, $url);
> }
> 
> add_filter('oauth1_base_request_uri', 'customized_oauth1_base_request_uri');

This approach allows us to ensure that the base URL matches what is expected, preventing the signature mismatch and ensuring the OAuth process works correctly.